### PR TITLE
chore(readme): Add Noir version compatibility description

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Features:
 - Efficient implementation ~2 gates per haystack byte, ~5 gates per needle byte
 - Both needle and haystack strings can be dynamically constructed in-circuit if required
 
-# Typedefs
+## Noir version compatibility
+
+This library is tested with all Noir stable releases from v0.36.0.
+
+## Typedefs
 
 Multiple type definitions represent different hardcoded maximum lengths for the needle/haystack:
 
@@ -36,7 +40,7 @@ SubString512
 SubString1024
 ```
 
-# Usage
+## Usage
 
 ### Basic usage
 


### PR DESCRIPTION
# Description

Resolves https://github.com/noir-lang/noir_string_search/issues/15

Specify version compatibility with all stables from Noir v0.36.0, as tested since https://github.com/noir-lang/noir_string_search/pull/10.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
