### PR TITLE
chore: replace usage of sha256 with blake3

### DIFF
--- a/src/utils.nr
+++ b/src/utils.nr
@@ -79,7 +79,7 @@ impl DebugRandomEngine {
     unconstrained fn get_random_32_bytes(&mut self) -> [u8; 32] {
         self.seed += 1;
         let input: [u8; 32] = self.seed.to_be_bytes();
-        let hash: [u8; 32] = dep::std::hash::sha256(input);
+        let hash: [u8; 32] = std::hash::blake3(input);
         hash
     }
     unconstrained fn get_random_field(&mut self) -> Field {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Part of https://github.com/noir-lang/noir/pull/7477

This PR switches us over to using a different hash function.

## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
